### PR TITLE
Bugfix: Sicherstellen, dass neuem Member kein Acc mitgegeben wird.

### DIFF
--- a/src/main/java/com/WWI16AMA/backend_api/Member/Member.java
+++ b/src/main/java/com/WWI16AMA/backend_api/Member/Member.java
@@ -49,7 +49,7 @@ public class Member {
 
     @OneToOne(cascade = CascadeType.ALL)
     @JsonIgnoreProperties({"balance", "transactions"})
-    private Account memberBankingAccount = new Account();
+    private Account memberBankingAccount;
 
     @ManyToMany
     private List<Office> offices;
@@ -76,6 +76,7 @@ public class Member {
         this.address = address;
         this.bankingAccount = bankingAccount;
         this.admissioned = admissioned;
+        this.memberBankingAccount = new Account();
     }
 
     public Member(Member member) {

--- a/src/main/java/com/WWI16AMA/backend_api/Member/MemberController.java
+++ b/src/main/java/com/WWI16AMA/backend_api/Member/MemberController.java
@@ -1,5 +1,6 @@
 package com.WWI16AMA.backend_api.Member;
 
+import com.WWI16AMA.backend_api.Account.Account;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -61,8 +62,13 @@ public class MemberController {
     public Member create(@RequestBody Member mem) {
 
         if (mem.getId() != null) {
-            throw new IllegalArgumentException("Id has to be null if you want to save a new Member");
+            throw new IllegalArgumentException("Id shall not be send if you want to create a new Member");
         }
+
+        if (mem.getMemberBankingAccount() != null) {
+            throw new IllegalArgumentException("Account shall not be send to create a new member");
+        }
+        mem.setMemberBankingAccount(new Account());
 
         List<Office> offices = mem.getOffices()
                 .stream()

--- a/src/test/java/com/WWI16AMA/backend_api/MemberTests.java
+++ b/src/test/java/com/WWI16AMA/backend_api/MemberTests.java
@@ -92,6 +92,7 @@ public class MemberTests {
         Member mem = new Member("Kurt", "Krömer",
                 LocalDate.of(1975, Month.DECEMBER, 2), Gender.MALE, Status.PASSIVE,
                 "karl.hansen@mail.com", adr, "DE12345678901234567890", false);
+        mem.setMemberBankingAccount(null);
 
         Office[] off = {new Office(Office.Title.FLUGWART), new Office(Office.Title.KASSIERER)};
         mem.setOffices(asList(off));


### PR DESCRIPTION
Vorher hat es einen 500er gegeben, wenn bei POST /members der Account
nicht null war. Ich hab mir gedacht, wir übernehmen die Regelung von
`id`, aber das erfordert ein paar Änderungen.