### PR TITLE
Delete-Flag bei Member, angepasstes Repository

### DIFF
--- a/src/main/java/com/WWI16AMA/backend_api/Application.java
+++ b/src/main/java/com/WWI16AMA/backend_api/Application.java
@@ -78,7 +78,8 @@ public class Application extends SpringBootServletInitializer {
                 "karl.hansen@mail.com", adr, "DE12345678901234567890", false,
                 enc.encode("koala"));
         // publisher.publishEvent(new EmailNotificationEvent(mem));
-        mem.setOffices(offices.stream().filter((of) -> of.getTitle().equals(Office.Title.VORSTANDSVORSITZENDER)).collect(Collectors.toList()));
+        mem.setOffices(offices.stream().filter((of) -> of.getTitle().equals(Office.Title.VORSTANDSVORSITZENDER)
+                || of.getTitle().equals(Office.Title.SYSTEMADMINISTRATOR)).collect(Collectors.toList()));
         mem.setFlightAuthorization(flList);
         mem.setId(9999);
         /**

--- a/src/main/java/com/WWI16AMA/backend_api/Member/Member.java
+++ b/src/main/java/com/WWI16AMA/backend_api/Member/Member.java
@@ -70,6 +70,8 @@ public class Member {
 
     @OneToOne(cascade = CascadeType.ALL)
     private PilotLog pilotLog;
+    @JsonIgnore
+    private boolean isDeleted;
 
     public Member() {
 
@@ -111,7 +113,6 @@ public class Member {
         this.flightAuthorization = member.getFlightAuthorization();
         this.pilotLog = member.getPilotLog();
     }
-
 
     public Integer getId() {
         return id;
@@ -239,6 +240,14 @@ public class Member {
 
     public PilotLog getPilotLog() {
         return pilotLog;
+    }
+
+    public boolean isDeleted() {
+        return isDeleted;
+    }
+
+    public void delete() {
+        this.isDeleted = true;
     }
 
     public enum Status {

--- a/src/main/java/com/WWI16AMA/backend_api/Member/MemberController.java
+++ b/src/main/java/com/WWI16AMA/backend_api/Member/MemberController.java
@@ -108,7 +108,8 @@ public class MemberController {
 
         Member dbMember = memberRepository.findById(id).orElseThrow(() ->
                 new NoSuchElementException("Member with the id " + id + " does not exist"));
-        memberRepository.delete(dbMember);
+        dbMember.delete();
+        memberRepository.save(dbMember);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 

--- a/src/main/java/com/WWI16AMA/backend_api/Member/MemberRepository.java
+++ b/src/main/java/com/WWI16AMA/backend_api/Member/MemberRepository.java
@@ -1,10 +1,30 @@
 package com.WWI16AMA.backend_api.Member;
 
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends PagingAndSortingRepository<Member, Integer> {
 
+    @Query(value = "SELECT * FROM member WHERE id = ?1 AND is_deleted = 0", nativeQuery = true)
+    Optional<Member> findById(Integer id);
+
+    @Query(value = "SELECT * FROM member WHERE is_deleted = 0", nativeQuery = true)
+    Iterable<Member> findAll();
+
+    @Query(value = "SELECT COUNT(*) FROM member WHERE is_deleted = 0", nativeQuery = true)
+    long count();
+
+    @Query(value = "SELECT * FROM member WHERE id = ?1", nativeQuery = true)
+    Optional<Member> findByIdIncludingDeleted(Integer id);
+
+    @Query(value = "SELECT * FROM member", nativeQuery = true)
+    Iterable<Member> findAllIncludingDeleted();
+
+    @Query(value = "SELECT COUNT(*) FROM member", nativeQuery = true)
+    long countIncludingDeleted();
 }

--- a/src/main/java/com/WWI16AMA/backend_api/Member/MemberUserDetails.java
+++ b/src/main/java/com/WWI16AMA/backend_api/Member/MemberUserDetails.java
@@ -57,6 +57,6 @@ public class MemberUserDetails extends Member implements UserDetails {
 
     @Override
     public boolean isEnabled() {
-        return true;
+        return !isDeleted();
     }
 }

--- a/src/test/java/com/WWI16AMA/backend_api/PilotLogTests.java
+++ b/src/test/java/com/WWI16AMA/backend_api/PilotLogTests.java
@@ -51,7 +51,7 @@ public class PilotLogTests {
         saveAndGetMember(memberRepository, officeRepository, passwordEncoder, "123password");
 
         // Check that an PilotLog was created
-        assertThat(memberRepository.count()).isEqualTo(pilotLogRepository.count());
+        assertThat(memberRepository.countIncludingDeleted()).isEqualTo(pilotLogRepository.count());
     }
 
     @Test


### PR DESCRIPTION
Member wird gelöscht per `member.delete()`, muss danach gespeichert werden.
Der Member wird dann nicht mehr bei `memberRepositoryfindById()` und `.findAll()` (sowie `.cont()` gefunden, aaaaber es gibt `.findByIdIncludingDeleted()` etc.

Shoutouts an Tim Harken. Airenmann.